### PR TITLE
DB Config adapter method

### DIFF
--- a/lib/friendly_uuid.rb
+++ b/lib/friendly_uuid.rb
@@ -69,7 +69,7 @@ module FriendlyUUID
     end
 
     def substr_query
-      case self.connection_config[:adapter]
+      case adapter
       when "mysql2"
         raise ValueError("Sorry, FriendlyUUID does not support MySQL")
       when "postgresql"
@@ -78,6 +78,14 @@ module FriendlyUUID
         "SUBSTR(#{self.table_name}.id, 0, ?) = ?"
       else
         raise ValueError("Unknown database type; FriendlyUUID cannot support it")
+      end
+    end
+
+    def adapter
+      if respond_to?(:connection_db_config)
+        connection_db_config.configuration_hash[:adapter]
+      else
+        connection_config[:adapter]
       end
     end
   end


### PR DESCRIPTION
Hi ✋🏼 

Rails 7 just got released and there is an error. The `connection_config ` method was [removed](https://edgeguides.rubyonrails.org/7_0_release_notes.html#active-job-removals).

This change will ensure to use `connection_db_config` whenever is possible.

